### PR TITLE
Add Docker Compose deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+.git
+Dockerfile
+docker-compose.yml
+*.log
+.next

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+DATABASE_URL=postgres://postgres:postgres@db:5432/painel

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ yarn-error.log*
 
 # env files
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Multi-stage build for smaller production image
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package.json pnpm-lock.yaml ./
+RUN corepack enable && corepack prepare pnpm@8.6.2 --activate && pnpm install --frozen-lockfile
+COPY . .
+RUN pnpm run build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app .
+EXPOSE 3000
+CMD ["pnpm","start"]

--- a/README.md
+++ b/README.md
@@ -101,6 +101,19 @@ Para fazer o deploy deste projeto na Vercel, siga os passos abaixo:
    * Clique no botão "Deploy". A Vercel irá construir e implantar sua aplicação.
    * Após a conclusão, você receberá uma URL pública para o seu projeto.
 
+## 🛰️ Deploy com Docker Compose
+
+Para manter os dados persistentes, utilize o `docker-compose.yml` incluído neste projeto.
+
+1. Copie `.env.example` para `.env` e preencha as variáveis.
+2. Construa e inicie os serviços:
+
+   ```bash
+   docker compose up -d --build
+   ```
+
+3. O volume `postgres-data` garante que o banco de dados PostgreSQL não seja perdido entre atualizações.
+
 ## 📜 Scripts Disponíveis
 
 No diretório do projeto, você pode executar:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.8'
+services:
+  app:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      NEXT_PUBLIC_SUPABASE_URL: ${NEXT_PUBLIC_SUPABASE_URL}
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${NEXT_PUBLIC_SUPABASE_ANON_KEY}
+      DATABASE_URL: postgres://postgres:postgres@db:5432/painel
+    depends_on:
+      - db
+  db:
+    image: postgres:15
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: painel
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+volumes:
+  postgres-data:


### PR DESCRIPTION
## Summary
- create Dockerfile for Next.js production
- add docker-compose with Postgres volume for persistent data
- provide env example
- document Docker Compose deploy in README
- allow tracking `.env.example`

## Testing
- `NEXT_PUBLIC_SUPABASE_URL=http://example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=anon npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688980da8188832ab4eb4022b65a279c