### PR TITLE
Add password reset function and login instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,24 @@ Siga as instruções abaixo para configurar e executar o projeto em seu ambiente
 
 4. Abra <http://localhost:3000> em seu navegador para ver a aplicação.
 
+### Credenciais Padrão
+
+Um usuário administrador inicial é criado pelo script `database-setup.sql`.
+Utilize as credenciais abaixo para o primeiro acesso:
+
+```
+Usuário: admin
+Senha: admin123!
+```
+
+Após o login, altere a senha imediatamente. Caso seja necessário redefinir a senha de qualquer usuário, execute:
+
+```bash
+psql -d v0_tactical_db -c "SELECT reset_user_password('admin', 'novaSenha');"
+```
+
+O comando acima usa a função `reset_user_password` adicionada ao banco de dados para atualizar o hash da senha.
+
 ## 🚀 Deploy na Vercel
 
 Para fazer o deploy deste projeto na Vercel, siga os passos abaixo:

--- a/scripts/database-setup.sql
+++ b/scripts/database-setup.sql
@@ -535,6 +535,23 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+-- Utility function to reset a user's password
+CREATE OR REPLACE FUNCTION reset_user_password(
+    p_username VARCHAR,
+    p_new_password VARCHAR
+) RETURNS VOID AS $$
+BEGIN
+    UPDATE users
+    SET password_hash = crypt(p_new_password, gen_salt('bf')),
+        updated_at = NOW()
+    WHERE username = p_username;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'User % not found', p_username;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
 -- Final message
 DO $$
 BEGIN


### PR DESCRIPTION
## Summary
- add `reset_user_password` stored procedure to database setup script
- document default admin credentials and password reset instructions in README

## Testing
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68899c4fdb40832ab33a19bb5647f7ae

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentação**
  * Adicionada uma seção sobre credenciais padrão no README, incluindo instruções para acesso inicial e alteração de senha do administrador.
  * Incluído exemplo de comando para redefinir a senha de qualquer usuário via banco de dados.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->